### PR TITLE
Feat: Upgrade iOS and Android native sdks to latest (fixes Xcode 13 compilation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 0.1.6 (2021-11-02)
+
+* Bumps native iOS sdk version to 2.2.4.
+* Bumps native Android sdk version to 3.0.2.

--- a/ReactNativeHelpScout.podspec
+++ b/ReactNativeHelpScout.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'Beacon', '~> 2.0.2'
+  s.dependency 'Beacon', '~> 2.2.4'
 
   s.frameworks = 'UIKit'
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,7 @@ android {
 }
 
 repositories {
+	mavenCentral()
 	mavenLocal()
 	maven {
 		// All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
@@ -58,7 +59,7 @@ repositories {
 	jcenter()
 }
 
-def _beaconVersion = safeExtGet("helpscoutBeacon", "2.0.2")
+def _beaconVersion = safeExtGet("helpscoutBeacon", "3.0.2")
 
 dependencies {
 	// ref:
@@ -67,7 +68,5 @@ dependencies {
 	implementation 'com.facebook.react:react-native:+'  // From node_modules
 
 	// noinspection GradleDynamicVersion
-	implementation "com.helpscout:beacon-core:${_beaconVersion}"
-	// noinspection GradleDynamicVersion
-	implementation "com.helpscout:beacon-ui:${_beaconVersion}"
+	implementation "com.helpscout:beacon:${_beaconVersion}"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-native-help-scout",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"main": "./dist/index.js",
 	"typings": "./dist/index.d.ts",
 	"repository": "git@github.com:codemotionapps/react-native-help-scout.git",


### PR DESCRIPTION
iOS failed to compile on Xcode 13 using 2.0.2, but compiles fine using the latest iOS native sdk version (2.2.4).

I also updated to the latest Android version as well.

@mnmaraes do you recall what the exact issue was for pinning 2.0.2 specifically here? https://github.com/levelshealth/react-native-help-scout/commit/dbde97fa8ffc945c5e7af5e06feba6d3afc82cb0

I assume it was this, which was fixed in 2.1.2

<img width="1047" alt="Screen Shot 2021-11-03 at 10 31 50 AM" src="https://user-images.githubusercontent.com/5117473/140092155-49b5d6a3-adc1-4e5d-bee2-4dd2b8a9d753.png">


- [ ] Hold the merge of this until the app's PR is merged that requires this is merged, unless the versioning in package.json actually works correctly?

Video of iOS

https://user-images.githubusercontent.com/5117473/140091324-261701ec-50e1-4f63-bda5-e51d40cbbc11.mp4

Android screenshot

![Screenshot_1635870063](https://user-images.githubusercontent.com/5117473/140091395-1163e4be-4976-4785-bf07-13e655643954.png)

