### PR TITLE
fix: gradle plugin v7 no longer has 'mavin' plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 // Matches values in recent template from React Native 0.59 / 0.60
 // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9


### PR DESCRIPTION
After upgrading to RN 0.68, Android builds failed since the new gradle plugin doesn't use mavin anymore and needs to use mavin-publish instead.